### PR TITLE
Invisibilty no longer effected by dispel

### DIFF
--- a/kod/object/passive/spell/persench/invis.kod
+++ b/kod/object/passive/spell/persench/invis.kod
@@ -141,7 +141,7 @@ messages:
 
    IsIllusion()
    {
-      return TRUE;
+      return FALSE;
    }
 
    EffectDesc(who=$)


### PR DESCRIPTION
Throughout the years, the spell Invisibilty had near to no uses. 

Invisibility was largely inferior to the "Ring of Invisibilty" because of the weakness to dispel illusion. The ring is undispellable but the spell itself was able to be removed by it. 

The spell's innate defensive properties are largely useless as in almost all PvP situations as fights are lead by Dispel Illusion. 

This minor buff will give some power to the spell by making it non-dispellable by the Dispel Illusion Krannan spell. All other methods of removal are unaffected. 